### PR TITLE
[2024-12-30] 유민국 - 과제 제출

### DIFF
--- a/docs/daily/2024-12-30.md
+++ b/docs/daily/2024-12-30.md
@@ -1,0 +1,67 @@
+# 2024-12-30
+
+## 📚 오늘 배운 내용
+
+### 제네릭
+
+- 타입이 없을때의 문제점
+    - 런타임 에러가 나기 쉽다
+    - IDE가 컴파일 에러를 미리 찾을 수 없다
+- 제네릭: 사용하는 시점에 타입을 원하는 형태로 정의할 수 있음
+- type safe 효과
+- ex) List<E> class, Map<K, V> class
+- 형식 매개변수 이름(강제사항은 없으나 일종의 규칙)
+
+| 형식 매개변수 이름 | 의미                  |
+|------------|---------------------|
+| E          | 요소(Element)         |
+| K          | 키(key)              |
+| N          | 숫자(Number)          |
+| T          | 형식(Type)            |
+| V          | 값(value)            |
+| S,U,V etc  | 2nd, 3rd, 4th types |
+
+- `out`: 읽기 전용(Covariance 공변성)
+- `in`: 쓰기 전용(Contravariance 반공변성)
+
+### enum class(열거형)
+
+- 정해 둔 값만 넣어둘 수 있는 타입
+- `enum class`는 `when`과 조합으로 모든 처리를 강제할 수 있음
+
+### 문자열 조작
+
+- subString
+- split
+- lowercase/uppercase
+- length
+- isEmpty
+- contains
+- endsWith
+- indexOf
+- lastIndexOf
+- trim
+- replace
+
+### 문자열 결합 방법
+
+- String interpolation
+- StringBuilder
+- StringBuffer
+
+### String
+
+- String 인스턴스는 불변 개체(immutable)
+
+## 💻 예제 코드
+
+[제네릭](../../src/main/kotlin/day10/Pocket.kt)  
+[enum class](../../src/main/kotlin/day10/AuthState.kt)  
+[연습문제1](../../src/main/kotlin/day10/StrongBox.kt)  
+[연습문제2](../../src/main/kotlin/day10/Word.kt)
+
+## 🔍 참고 자료
+
+## ❓ 궁금한 점
+
+## 💡 기타 사항

--- a/src/main/kotlin/day10/AuthState.kt
+++ b/src/main/kotlin/day10/AuthState.kt
@@ -1,0 +1,15 @@
+package org.example.day10
+
+//class AuthState {
+//    companion object {
+//        const val AUTHENTICATED = 1
+//        const val UNAUTHORIZED = 2
+//        const val UNKNOWN = 3
+//    }
+//}
+
+// enum class 사용
+// enum 클래스는 when과 조합으로 모든 처리를 강제할 수 있음
+enum class AuthState{
+    AUTHENTICATED, UNAUTHORIZED, UNKNOWN
+}

--- a/src/main/kotlin/day10/Pocket.kt
+++ b/src/main/kotlin/day10/Pocket.kt
@@ -1,0 +1,34 @@
+package org.example.day10
+
+import org.example.day09.Book
+import org.intellij.lang.annotations.JdkConstants.AdjustableOrientation
+
+// 제네릭을 사용하지 않은 클래스
+//class Pocket {
+//    private var _data: Any? = null
+//    fun put(data:Any){
+//        _data = data
+//    }
+//
+//    fun get(): Any? = _data
+//}
+
+// 제네릭 사용
+//class Pocket<E> {
+//    private var _data: E? = null
+//    fun put(data: E) {
+//        _data = data
+//    }
+//
+//    fun get(): E? = _data
+//}
+
+// 이용 가능한 타입에 제약을 추가한 Pocket 클래스
+class Pocket<E:Book> {
+    private var _data: E? = null
+    fun put(data: E) {
+        _data = data
+    }
+
+    fun get(): E? = _data
+}

--- a/src/main/kotlin/day10/StrongBox.kt
+++ b/src/main/kotlin/day10/StrongBox.kt
@@ -1,0 +1,39 @@
+package org.example.day10
+
+enum class KeyType(val unlockCnt: Int) {
+    PADLOCK(1_024),
+    BUTTON(10_000),
+    DIAL(30_000),
+    FINGER(1_000_000),
+}
+
+enum class Error(val message: String) {
+    EMPTY("금고가 비어 있습니다.")
+}
+
+class StrongBox<T : Any>(
+    private val keyType: KeyType
+) {
+    private var getCnt: Int = 0
+    private var item: T? = null
+
+    fun put(item: T) {
+        getCnt = 0
+        this.item = item
+    }
+
+    fun get(): T? {
+        require(item != null) { Error.EMPTY.message }
+
+        getCnt += 1
+
+        var result: T? = null
+        if (keyType.unlockCnt <= getCnt) {
+            result = item
+            item = null
+        }
+
+
+        return result
+    }
+}

--- a/src/main/kotlin/day10/Word.kt
+++ b/src/main/kotlin/day10/Word.kt
@@ -1,0 +1,22 @@
+package org.example.day10
+
+class Word(
+    var word: String
+) {
+    private val isVowel = BooleanArray(26)
+
+    init {
+        "aeiou".forEach {
+            isVowel[it.code - 'a'.code] = true
+        }
+    }
+
+    private fun isLetter(index: Int): Boolean = word[index].isLetter()
+    private fun getCode(index: Int): Int = word.lowercase()[index].code - 'a'.code
+
+    fun isVowel(index: Int): Boolean = isLetter(index) && isVowel[getCode(index)]
+
+    fun isConsonant(index: Int): Boolean =
+        isLetter(index) && !isVowel[getCode(index)]
+
+}

--- a/src/test/kotlin/day10/StrongBoxTest.kt
+++ b/src/test/kotlin/day10/StrongBoxTest.kt
@@ -1,0 +1,76 @@
+package day10
+
+import org.example.day07.Asset
+import org.example.day07.Computer
+import org.example.day09.Book
+import org.example.day10.KeyType
+import org.example.day10.StrongBox
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class StrongBoxTest {
+
+    @Before
+    fun setUp() {
+    }
+
+    @Test
+    fun `다양한 타입 생성 테스트`() {
+        assertDoesNotThrow {
+            val sb1 = StrongBox<Book>(KeyType.DIAL)
+            val sb2 = StrongBox<Asset>(KeyType.BUTTON)
+            val sb3 = StrongBox<Computer>(KeyType.FINGER)
+        }
+    }
+
+    @Test
+    fun `put() test`() {
+        val item = Book("소중한 책", "소중한")
+        val bookStrongBox = StrongBox<Book>(KeyType.PADLOCK)
+        bookStrongBox.put(item)
+        repeat(KeyType.PADLOCK.unlockCnt - 1) {
+            bookStrongBox.get()
+        }
+
+        assertEquals(item, bookStrongBox.get())
+    }
+
+    @Test
+    fun `get() test`() = assertAll(
+        "금고가 비었을 때, 모든 keyType 확인, 금고에서 아이템을 꺼낸 후 다시 꺼낼 때",
+        {
+            val bookStrongBox = StrongBox<Book>(KeyType.DIAL)
+            assertThrows(IllegalArgumentException::class.java) {
+                bookStrongBox.get()
+            }
+        },
+        {
+            KeyType.entries.forEach { keyType ->
+                val bookStrongBox = StrongBox<Book>(keyType)
+                val book = Book("소중한 책", "소중한")
+                bookStrongBox.put(book)
+                repeat(keyType.unlockCnt - 1) { time ->
+                    val item = bookStrongBox.get()
+                    if (time % 100 == 0) {
+                        assertNull(item)
+                    }
+                }
+                assertEquals(book, bookStrongBox.get())
+            }
+        },
+        {
+            val bookStrongBox = StrongBox<Book>(KeyType.PADLOCK)
+            val book = Book("소중한 책", "소중한")
+            bookStrongBox.put(book)
+            repeat(KeyType.PADLOCK.unlockCnt) {
+                bookStrongBox.get()
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                bookStrongBox.get()
+            }
+        }
+    )
+}

--- a/src/test/kotlin/day10/WordTest.kt
+++ b/src/test/kotlin/day10/WordTest.kt
@@ -1,0 +1,29 @@
+package day10
+
+import org.example.day10.Word
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class WordTest() {
+    private val word = Word("ApPle^^2")
+
+    @Before
+    fun setUp() {
+
+    }
+
+    @Test
+    fun `isVowel() test`() {
+        assertTrue(word.isVowel(0))
+        assertTrue(word.isVowel(4))
+        assertFalse(word.isVowel(5))
+    }
+
+    @Test
+    fun `isConsonant() test`() {
+        assertTrue(word.isConsonant(1))
+        assertTrue(word.isConsonant(2))
+        assertFalse(word.isConsonant(6))
+    }
+}


### PR DESCRIPTION
# 과제 제출

## 📝 과제 내용
<!-- 구현한 과제의 주요 내용을 간단히 작성해주세요 -->
- 제네릭과 enum class를 사용해 StrongBox 클래스 구현
- 영단어에서 i번째 글자가 모음 또는 자음인지를 알려주는 함수 구현

## ✨ 구현 내용
<!-- 중요한 구현 내용을 bullet point로 작성해주세요 -->
### StrongBox
- enum class 구현
  - 네 가지 열쇠 종류와 각 열쇠의 정해진 시도횟수로 enum class 생성
- put() 함수 구현 
  - 제네릭 타음으로 null이 아닌 모든 객체를 받을 수 있게
- get() 함수 구현
  - 아이템이 비어있으면 예외 발생
  -  정해진 시도횟수 이상일 경우 금고에 들어있는 아이템 반환
### Word 클래스
- 26의 size를 가진 boolean 타입의 배열을 만들고 모음이 아니면 false 
- i번째 글자가 알파벳이 아니면 false 반환

## 🤔 고민한 점
<!-- 과제를 하면서 고민했던 점이나 어려웠던 점을 작성해주세요 -->


## ❓ 질문
<!-- 궁금한 점이나 리뷰어에게 묻고 싶은 점을 작성해주세요 -->


## 📚 참고 자료
<!-- 과제를 하면서 참고한 자료가 있다면 작성해주세요 -->


---
### ✅ 제출 전 체크리스트
- [x] 모든 테스트가 통과하나요?
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 커밋 메시지는 명확하게 작성하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
	- 2024년 12월 30일 학습 내용에 대한 새로운 마크다운 문서 추가

- **새로운 기능**
	- 제네릭, 열거형 클래스, 문자열 조작에 대한 개념 문서화
	- 인증 상태를 관리하는 `AuthState` 열거형 클래스 추가
	- 제네릭 타입을 사용하는 `Pocket` 클래스 도입
	- 키 유형에 따른 보안 메커니즘을 가진 `StrongBox` 클래스 구현
	- 단어 내 모음/자음을 판별하는 `Word` 클래스 생성

- **테스트**
	- `StrongBox`와 `Word` 클래스에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->